### PR TITLE
Made i2c_scan actually usable

### DIFF
--- a/lib_i2c.c
+++ b/lib_i2c.c
@@ -161,18 +161,17 @@ i2c_err_t i2c_ping(const uint8_t addr)
 }
 
 
-void i2c_scan(void)
+void i2c_scan(i2c_scan_callback_t callback, void *userdata)
 {
-	printf("--Scanning I2C Bus--\n");
 	// Scan through every address, getting a ping() response
 	for(uint8_t addr = 0x00; addr < 0x7F; addr++)
 	{
 		// If the address responds, set the return status, and print
 		uint8_t real_addr = addr << 1; // Actual 7bit address being scanned
-		if(i2c_ping(real_addr) == I2C_OK) printf("\tDevice 0x%02X Responded\n", real_addr);
+		if(i2c_ping(real_addr) == I2C_OK) callback(real_addr, userdata);
 	}
-	printf("--Done Scanning--\n");
 }
+
 
 
 i2c_err_t i2c_read(const uint8_t addr,    const uint8_t reg,

--- a/lib_i2c.h
+++ b/lib_i2c.h
@@ -105,9 +105,10 @@ i2c_err_t i2c_init(const uint32_t clk_rate);
 i2c_err_t i2c_ping(const uint8_t addr);
 
 /// @brief Scans through all 7 Bit addresses, prints any that respond
-/// @param None
+/// @param callback function pointer called with discovered address and userdata
+/// @param userdata pointer passed to callback
 /// @return None
-void i2c_scan(void);
+void i2c_scan(i2c_scan_callback_t callback, void *userdata);
 
 /// @brief reads [len] bytes from [addr]s [reg] register into [buf]
 /// @param addr, address of I2C Device to Read from, MUST BE 7 Bit

--- a/lib_i2c.h
+++ b/lib_i2c.h
@@ -104,7 +104,7 @@ i2c_err_t i2c_init(const uint32_t clk_rate);
 /// @return i2c_err_t, I2C_OK if the device responds
 i2c_err_t i2c_ping(const uint8_t addr);
 
-/// @brief Scans through all 7 Bit addresses, prints any that respond
+/// @brief Scans through all 7 Bit addresses
 /// @param callback function pointer called with discovered address and userdata
 /// @param userdata pointer passed to callback
 /// @return None


### PR DESCRIPTION
Makes `i2c_scan` call a callback whenever an address is discovered instead of printing to to stdout where it probably goes nowhere.

**Please squash when merging!!**